### PR TITLE
Create FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,3 @@
-# These are supported funding model platforms
-
-# Expenses: https://github.com/StackStorm/discussions/issues/36
+# Github donate button to https://funding.communitybridge.org/projects/stackstorm
+# StackStorm Expenses: https://github.com/StackStorm/discussions/issues/36
 community_bridge: stackstorm

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# These are supported funding model platforms
+
+# Expenses: https://github.com/StackStorm/discussions/issues/36
+community_bridge: stackstorm


### PR DESCRIPTION
> Related to: https://github.com/StackStorm/discussions/issues/36

This PR adds Github Donate button in this repo that will link to StackStorm Community Bridge Account:
https://funding.communitybridge.org/projects/stackstorm

This is just a preparation. We'll do this for every repo in StackStorm and StackStorm-Exchange soon.